### PR TITLE
Explicitely secified the Java version requirement and fixed a maven related encoding warning.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,38 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.stefanmuenchow</groupId>
-  <artifactId>generic-arithmetic</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
+	<groupId>com.stefanmuenchow</groupId>
+	<artifactId>generic-arithmetic</artifactId>
+	<version>1.0.0</version>
+	<packaging>jar</packaging>
 
-  <name>Generic-Arithmetic</name>
-  <url>http://www.stefanmuenchow.com</url>
+	<name>Generic-Arithmetic</name>
+	<url>http://www.stefanmuenchow.com</url>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.8.2</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.2</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Fixed minimum java version requirement and fixed a maven related warning during the compilation. The @Override annotation for Java 1.5 does not cover the implementation of the methods of an Interface. It can only be used in this context starting from Java 1.6 (see http://stackoverflow.com/questions/94361/when-do-you-use-javas-override-annotation-and-why). A different approach would be to remove the @Override annotations to allow Java 1.5 compatibility.
